### PR TITLE
:Fix: Accounting for language format ru-RU in metadata

### DIFF
--- a/bot-widget.js
+++ b/bot-widget.js
@@ -1,6 +1,6 @@
 // Interactive Chat Widget for n8n
 (function() {
-    const detectedLang = document.documentElement.lang || 'en';
+    const detectedLang = (document.documentElement.lang || 'en').split('-')[0].toLowerCase();
     // Initialize widget only once
     if (window.N8nChatWidgetLoaded) return;
     window.N8nChatWidgetLoaded = true;


### PR DESCRIPTION
I found out that when you switch to Russian, the language element in the metadata says "ru-RU", not just "ru", that is why the Russian version did not work.
I fixed the code to account for that language format.